### PR TITLE
Merge »button« feature branch into main

### DIFF
--- a/catppuccin.css
+++ b/catppuccin.css
@@ -152,14 +152,14 @@
     
     /* BUTTONS */   
     --color-btn-text: var(--__white) !important;
-    --color-btn-bg: var(--__black1) !important;
-    --color-btn-border: var(--color-border-subtle) !important;
-    --color-btn-hover-bg: var(--__black1) !important;
-    --color-btn-hover-border: var(--color-border-default) !important;
-    --color-btn-active-bg: var(--__black1) !important;
-    --color-btn-active-border: var(--color-btn-hover-border) !important;
-    --color-btn-selected-bg: var(--__black1) !important;
-    --color-btn-focus-bg: var(--__black1) !important;
+    --color-btn-bg: var(--__black3) !important;
+    --color-btn-border: var(--color-btn-bg) !important;
+    --color-btn-hover-bg: var(--__black4) !important;
+    --color-btn-hover-border: var(--color-btn-hover-bg) !important;
+    --color-btn-active-bg: var(--__black4) !important;
+    --color-btn-active-border: var(--color-btn-active-bg) !important;
+    --color-btn-selected-bg: var(--__black3) !important;
+    --color-btn-focus-bg: var(--__black3) !important;
     --color-btn-primary-text: var(--__black2) !important;
     --color-btn-primary-bg: var(--__green_darkest) !important;
     --color-btn-primary-hover-bg: var(--__green_darken) !important;

--- a/catppuccin.css
+++ b/catppuccin.css
@@ -160,6 +160,7 @@
     --color-btn-active-border: var(--color-btn-active-bg) !important;
     --color-btn-selected-bg: var(--__black3) !important;
     --color-btn-focus-bg: var(--__black3) !important;
+    --color-btn-counter-bg: var(--__black2) !important;
     --color-btn-primary-text: var(--__black2) !important;
     --color-btn-primary-bg: var(--__green_darkest) !important;
     --color-btn-primary-hover-bg: var(--__green_darken) !important;


### PR DESCRIPTION
This changes buttons from the outlined look to a solid look by making the border- and background colours identical. It also fixes a small issue where the counter on buttons was not coloured within the Catppuccin colour scheme.