### PR TITLE
Fix Latte box-shadow too bold

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -43,6 +43,7 @@
         $base = #eff1f5
         $mantle = #e6e9ef
         $crust = #dce0e8
+        $shadow = #dbdfef
     }
     else if (theme=="Frappe") {
         $type = dark
@@ -73,6 +74,7 @@
         $base = #303446
         $mantle = #292c3c
         $crust = #232634
+        $shadow = #010409
     }
     else if (theme=="Macchiato") {
         $type = dark
@@ -103,6 +105,7 @@
         $base = #24273a
         $mantle = #1e2030
         $crust = #181926
+        $shadow = #010409
     }
     else if (theme=="Mocha") {
         $type = dark
@@ -133,6 +136,7 @@
         $base = #1e1e2e
         $mantle = #181825
         $crust = #11111b
+        $shadow = #010409
     }
     
     /* Functions */
@@ -458,9 +462,9 @@
         --color-border-muted:  $surface0;
         --color-border-subtle: rgba(240, 246, 252, 0.1);
         --color-shadow-small: 0 0 transparent;
-        --color-shadow-medium: 0 3px 6px #010409;
-        --color-shadow-large: 0 8px 24px #010409;
-        --color-shadow-extra-large: 0 12px 48px #010409;
+        --color-shadow-medium: 0 3px 6px $shadow;
+        --color-shadow-large: 0 8px 24px $shadow;
+        --color-shadow-extra-large: 0 12px 48px $shadow;
         --color-neutral-emphasis-plus: #6e7681;
         --color-neutral-emphasis: $overlay2;
         --color-neutral-muted: rgba(110, 118, 129, 0.4);


### PR DESCRIPTION
This PR fixes the drop shadow in the Latte theme.

- I created a new `$shadow` variable, as others are not strong enough for some components ;
- The latte shadow is picked "randomly". Don't hesitate to suggest another one that fits the Catppuccin themes better if this one is not good.

## Screenshots

| Before | After |
| --- | --- |
| ![before-1](https://user-images.githubusercontent.com/12123721/182038879-76ce6dcf-3cb8-4f8c-a570-9009f0f61c6c.png) | ![after-1](https://user-images.githubusercontent.com/12123721/182038874-0c87e919-6708-45f6-bb4e-3bc138040e0a.png) | 
| ![before-2](https://user-images.githubusercontent.com/12123721/182038895-2e57ddd5-5bd0-4edf-ac3c-f0fd43979c6b.png) | ![after-2](https://user-images.githubusercontent.com/12123721/182038901-29645b01-4096-4a06-aada-9617e6d92507.png) |