### PR TITLE
Use regex to avoid styling actions marketplace

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -11,7 +11,7 @@
 @var checkbox blueaccent "Blue Accent" 0
 @var checkbox usefont "Use Inter font" 0
 ==/UserStyle== */
-@-moz-document regexp("https://(\\w*\\.)*github.com(?!/marketplace/).*") {
+@-moz-document regexp("https://(gists\.)*github.com(?!/marketplace).*") {
   if (theme=="Latte") {
         $type = light
         

--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -1,3 +1,16 @@
+/* ==UserStyle==
+@name           Github Catppuccin
+@namespace      github.com/catppuccin/github
+@version        1.1.4
+@description    Soothing pastel theme for GitHub
+@author         Catppuccin
+@updateURL      https://github.com/catppuccin/github/raw/main/catppuccin.user.css
+@preprocessor   stylus
+@var select theme "Theme" ["Latte", "Frappe", "Macchiato", "Mocha*"]
+@var checkbox topbar "Topbar colors" 1
+@var checkbox blueaccent "Blue Accent" 0
+@var checkbox usefont "Use Inter font" 0
+==/UserStyle== */
 @-moz-document regexp("https://(\\d*\\.)*github.com(?!/marketplace/).*") {
     if (theme=="Latte") {
         $type = light

--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -1,19 +1,4 @@
-/* ==UserStyle==
-@name           Github Catppuccin
-@namespace      github.com/catppuccin/github
-@version        1.1.4
-@description    Soothing pastel theme for GitHub
-@author         Catppuccin
-@updateURL      https://github.com/catppuccin/github/raw/main/catppuccin.user.css
-@preprocessor   stylus
-
-@var select theme "Theme" ["Latte", "Frappe", "Macchiato", "Mocha*"]
-@var checkbox topbar "Topbar colors" 1
-@var checkbox blueaccent "Blue Accent" 0
-@var checkbox usefont "Use Inter font" 0
-
-==/UserStyle== */
-@-moz-document url-prefix("https://github.com"), url-prefix("https://gist.github.com") {
+@-moz-document regexp("https://(\\d*\\.)*github.com(?!/marketplace/).*") {
     if (theme=="Latte") {
         $type = light
         

--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -11,8 +11,8 @@
 @var checkbox blueaccent "Blue Accent" 0
 @var checkbox usefont "Use Inter font" 0
 ==/UserStyle== */
-@-moz-document regexp("https://(\\d*\\.)*github.com(?!/marketplace/).*") {
-    if (theme=="Latte") {
+@-moz-document regexp("https://(\\w*\\.)*github.com(?!/marketplace/).*") {
+  if (theme=="Latte") {
         $type = light
         
         $rosewater = #dc8a78


### PR DESCRIPTION
github actions marketplace is light-mode only for now.

I think it will see a lot of styling updates in the near future, so there is no point touching it for now until the stock stylesheet schema becomes more stable.

This change simply enables the catppuccin/github theme on any non-marketplace github url.