### PR TITLE
fix: fallback font-family to sans-serif

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -764,7 +764,7 @@
   if (usefont) {
       body,
       .markdown-body {
-          font-family: inter;
+          font-family: inter, sans-serif;
       }
   }
 


### PR DESCRIPTION
This fixes the problem that the characters doesn't exist in Inter falls back to serif typeface.

Before:
![Screenshot 2022-12-01 at 01-36-29 Issues · google_mozc](https://user-images.githubusercontent.com/18283756/204857091-32ec7949-23ae-485d-b113-055cca74cf21.png)

After:
![Screenshot 2022-12-01 at 01-44-41 Issues · google_mozc](https://user-images.githubusercontent.com/18283756/204857485-718e682e-29d5-430d-8c24-9d3e2a0734fe.png)
