### PR TITLE
fix: new app header

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -785,6 +785,10 @@
   .navigation-item[aria-selected="true"] .color-fg-muted {
       color: $base !important;
   }
+  /* Darker bg for new AppHeader */
+  .AppHeader {
+      background: var(--color-header-bg);
+  }
   /* Headers */
   h1, h2, h3, h4, h5, h6 {
       color: $subtext1


### PR DESCRIPTION
This PR makes the new [app header](https://github.com/orgs/community/discussions/52083) darker to keep it consistent

- Before ![before](https://user-images.githubusercontent.com/40269790/230308545-a16ed6b6-7ece-40b0-8675-1e1c89a2edc4.png)

- After ![after](https://user-images.githubusercontent.com/40269790/230308574-f5473b3c-4b24-4664-b295-7ab70bc4f1d0.png)
