### PR TITLE
Fix Latte Search Text Color

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -699,6 +699,10 @@
     background: var(--color-btn-danger-bg)
   }
 
+  .header-search-button.placeholder {
+      color: $text
+  }
+
   /* Issue tags */
   .hx_IssueLabel {
     --text: $text;


### PR DESCRIPTION
Fixes an issue where the search bar placeholder text in the Latte flavor is completely white. The color was replaced with $text as seen in the image below.

### Before: 
![image](https://github.com/catppuccin/github/assets/55212800/505e60d5-e40b-4301-b83f-07ecb29622e8)

### After:
![image](https://github.com/catppuccin/github/assets/55212800/b34d2abf-4649-4210-88cf-28637e48a984)
